### PR TITLE
Fix lore bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target/
+/.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -39,14 +39,15 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.13.1-R0.1-SNAPSHOT</version>
+			<version>1.16.4-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.black_ixx</groupId>
 			<artifactId>BossShopPro</artifactId>
 			<version>2.0.0</version>
-			<scope>provided</scope>
+			<systemPath>${project.basedir}/lib/BossShopPro.jar</systemPath>
+			<scope>system</scope>
 		</dependency>
 	</dependencies>
 	<description>PlayerShops GUI is the most playerfriendly shop plugin.

--- a/src/main/java/org/black_ixx/bossshop/addon/playershops/listener/SignListener.java
+++ b/src/main/java/org/black_ixx/bossshop/addon/playershops/listener/SignListener.java
@@ -75,19 +75,16 @@ public class SignListener implements Listener {
             if (e.getAction() == Action.RIGHT_CLICK_BLOCK) {
 
                 Block b = e.getClickedBlock();
-                if (b.getType() == Material.SIGN || b.getType() == Material.WALL_SIGN) {
+                if (b.getState() instanceof Sign) {
+                    Sign s = (Sign) b.getState();
 
-                    if (b.getState() instanceof Sign) {
-                        Sign s = (Sign) b.getState();
-
-                        String text = s.getLine(0).toLowerCase();
-                        if (text.endsWith(plugin.getSettings().getSignsTextPlayerShop().toLowerCase())) {
-                            plugin.getCommandManager().tryOpenShop(e.getPlayer(), ChatColor.stripColor(s.getLine(1)), true);
-                        } else if (text.endsWith(plugin.getSettings().getSignsTextShopListing().toLowerCase())) {
-                            plugin.getShopsManager().openShoplist(e.getPlayer());
-                        }
-
+                    String text = s.getLine(0).toLowerCase();
+                    if (text.endsWith(plugin.getSettings().getSignsTextPlayerShop().toLowerCase())) {
+                        plugin.getCommandManager().tryOpenShop(e.getPlayer(), ChatColor.stripColor(s.getLine(1)), true);
+                    } else if (text.endsWith(plugin.getSettings().getSignsTextShopListing().toLowerCase())) {
+                        plugin.getShopsManager().openShoplist(e.getPlayer());
                     }
+
                 }
             }
         }

--- a/src/main/java/org/black_ixx/bossshop/addon/playershops/objects/PlayerShopItem.java
+++ b/src/main/java/org/black_ixx/bossshop/addon/playershops/objects/PlayerShopItem.java
@@ -141,10 +141,11 @@ public class PlayerShopItem {
         }
 
         List<String> list = meta.getLore();
-        if (has_lore) { //Separate new info lore and item lore
-            list.add(0, " ");
-            list.add(0, " ");
+        if (list == null) { //Separate new info lore and item lore
+            list = new ArrayList<String>();
         }
+        list.add(0, " ");
+        list.add(0, " ");
         if (levels.length == 1) {
             list.add(0, plugin.getMessages().get("ItemPreview.LoreAny"));
         } else {

--- a/src/main/java/org/black_ixx/bossshop/addon/playershops/objects/PlayerShopItem.java
+++ b/src/main/java/org/black_ixx/bossshop/addon/playershops/objects/PlayerShopItem.java
@@ -184,10 +184,11 @@ public class PlayerShopItem {
         }
 
         List<String> list = meta.getLore();
-        if (has_lore) { //Separate new info lore and item lore
-            list.add(0, " ");
-            list.add(0, " ");
+        if(list == null) {
+            list = new ArrayList<String>();
         }
+        list.add(0, " ");
+        list.add(0, " ");
 
         list.add(0, plugin.getMessages().get("ItemEditPreview.Rest"));
         list.add(0, " ");


### PR DESCRIPTION
Hello, we had a NullPointerException error occur at line `list.add(0, plugin.getMessages().get("ItemPreview.LoreMiddle"));`.
This PR fixes the error. I think it was because the item didn't have a lore? Not sure.

It also used to throw an ArrayIndexOutOfBoundsException each time `/playershop` was executed, but this change fixed that too.
